### PR TITLE
Usability fix: added reset, preview button and update keybinding.

### DIFF
--- a/index.css
+++ b/index.css
@@ -20,8 +20,12 @@ iframe {
 }
 
 .lock-url {
-  margin: 15px 5%;
+  margin: 15px 0 5%;
   padding: 5px;
   width: 90%;
   font-family: monospace;
+}
+
+.action-bar {
+  text-align: right;
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,26 @@
   <body class="container-fluid">
   <div class="row">
     <div class="col-sm-6">
+      <nav class="navbar navbar-default row">
+        <div class="container-fluid">
+          <div class="navbar-header">
+            <a class="navbar-brand" href="#">Locker Playground</a>
+          </div>
+          <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+              <li id="reset-button" class="active">
+                <button class="btn btn-default navbar-btn btn-danger">Reset</button>
+              </li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right">
+              <li class="active">
+                <span class="label label-default">Ctrl + Enter</span>
+                <button id="preview-button" class="btn btn-default navbar-btn btn-success">Preview</button>
+              </li>
+            <ul>
+          </div>
+        </div>
+      </nav>
       <form>
         <input type="text" class="js-lock-url lock-url" value="//cdn.auth0.com/js/lock-9.2.js" placeholder="Type lock url here" title="Lock URL" />
       </form>

--- a/index.js
+++ b/index.js
@@ -87,5 +87,22 @@ function onChange(instance) {
 
 window.addEventListener('load', function () { onChange(editor); } );
 
-editor.on('change', _.debounce(onChange, 500));
 document.querySelector('.js-lock-url').addEventListener('input', function () { onChange(editor); });
+
+document.querySelector('#reset-button').addEventListener('click', function() {
+  var reset = window.confirm('Are you sure you want to reset the code to the initial state?\nAny change in the code will be lost.');
+  if (reset) {
+    editor.setValue(startTemplate({}));
+    onChange(editor);
+  }
+});
+
+document.querySelector('#preview-button').addEventListener('click', function() {
+  onChange(editor);
+});
+
+window.addEventListener('keypress', function(event) {
+  if ((event.keyCode === 10 || event.keyCode === 13) && event.ctrlKey) {
+    onChange(editor);
+  }
+});


### PR DESCRIPTION
The playground editor was not very usable as after each keypress the lock was reloading and capturing the cursor on the username box so I could not type anything else. I had to click back on the editor window and continue typing very fast before the "auto reload" was triggered.

I decided to disable the auto reload and add an update button which can be also triggered with "Ctrl+Enter". 

As I saw there was an issue open to add "Reset" button I decided to add it as well.